### PR TITLE
Add ability to generate non-byte access by reg API

### DIFF
--- a/src/tvip_axi_ral_adapter.svh
+++ b/src/tvip_axi_ral_adapter.svh
@@ -13,6 +13,7 @@ class tvip_axi_ral_adapter extends uvm_reg_adapter;
     axi_item                = tvip_axi_master_item::type_id::create("axi_item");
     axi_item.address        = rw.addr;
     axi_item.need_response  = 1;
+    axi_item.burst_size     = rw.n_bits/8;
     if (rw.kind == UVM_WRITE) begin
       axi_item.access_type  = TVIP_AXI_WRITE_ACCESS;
       axi_item.data         = new[1];
@@ -34,6 +35,7 @@ class tvip_axi_ral_adapter extends uvm_reg_adapter;
     rw.kind     = (axi_item.is_write()) ? UVM_WRITE : UVM_READ;
     rw.data     = axi_item.data[0];
     rw.byte_en  = (axi_item.is_write()) ? axi_item.strobe[0] : rw.byte_en;
+    rw.n_bits   = axi_item.burst_size*8;
     rw.status   = get_status(axi_item);
   endfunction
 


### PR DESCRIPTION
This commit adds ability to generate non-byte write/read transactions on AXI interface while using UVM register API.
Previously there were only byte transactions on the bus.