### PR TITLE
Change tvip_axi_data typedef from bit to logic to handle 4-state value

### DIFF
--- a/src/tvip_axi_ral_adapter.svh
+++ b/src/tvip_axi_ral_adapter.svh
@@ -43,12 +43,11 @@ class tvip_axi_ral_adapter extends uvm_reg_adapter;
   endfunction
 
   protected function uvm_status_e get_status(tvip_axi_item axi_item);
-    case (axi_item.response[0])
-      TVIP_AXI_OKAY:          return UVM_IS_OK;
-      TVIP_AXI_EXOKAY:        return UVM_IS_OK;
-      TVIP_AXI_SLAVE_ERROR:   return UVM_NOT_OK;
-      TVIP_AXI_DECODE_ERROR:  return UVM_NOT_OK;
-    endcase
+    if (axi_item.response[0] inside {TVIP_AXI_SLAVE_ERROR, TVIP_AXI_SLAVE_ERROR})
+      return UVM_NOT_OK;
+    if ($isunknown(axi_item.data[0]))
+      return UVM_HAS_X;
+    return UVM_IS_OK;
   endfunction
 
   `uvm_object_utils(tvip_axi_ral_adapter)

--- a/src/tvip_axi_ral_adapter.svh
+++ b/src/tvip_axi_ral_adapter.svh
@@ -43,10 +43,12 @@ class tvip_axi_ral_adapter extends uvm_reg_adapter;
   endfunction
 
   protected function uvm_status_e get_status(tvip_axi_item axi_item);
-    if (axi_item.response[0] inside {TVIP_AXI_SLAVE_ERROR, TVIP_AXI_SLAVE_ERROR})
+    if (axi_item.response[0] inside {TVIP_AXI_SLAVE_ERROR, TVIP_AXI_SLAVE_ERROR}) begin
       return UVM_NOT_OK;
-    if ($isunknown(axi_item.data[0]))
+    end
+    if ($isunknown(axi_item.data[0])) begin
       return UVM_HAS_X;
+    end
     return UVM_IS_OK;
   endfunction
 

--- a/src/tvip_axi_types_pkg.sv
+++ b/src/tvip_axi_types_pkg.sv
@@ -68,7 +68,7 @@ package tvip_axi_types_pkg;
     TVIP_AXI_WRAPPING_BURST     = 'b10
   } tvip_axi_burst_type;
 
-  typedef bit [`TVIP_AXI_MAX_DATA_WIDTH-1:0]  tvip_axi_data;
+  typedef logic [`TVIP_AXI_MAX_DATA_WIDTH-1:0]  tvip_axi_data;
 
   typedef bit [`TVIP_AXI_MAX_DATA_WIDTH/8-1:0]  tvip_axi_strobe;
 


### PR DESCRIPTION
@taichi-ishitani This PR is related to #29. This change makes RAL adapter return UVM_HAS_X if read data contains X or Z value.